### PR TITLE
JetS3 migrated to AWS SDK + Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,20 @@
-.DS_Store
+# GRAILS files
+/web-app/WEB-INF
 /target
+/target-eclipse
+
+# IDE files
+.classpath
+.idea/
+.project
+.settings
+/*.launch
+/*.tmproj
+
+*.log
+*.zip
+*.iml
+*.sha1
+/out
+plugin.xml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ Karman AWS
 Karman AWS is a S3 implementation of the Karman Cloud Service / Storage Interface. It allows one to interact with Amazon S3 via the standard Karman API interfaces
 
 
+Configuration
+-------------
+
+Since the plugin uses [AWS SDK](http://grails.org/plugin/aws-sdk) Grails Plugin, you can add your AWS credentials parameters to your grails-app/conf/Config.groovy :
+
+```groovy
+grails.plugin.awssdk.accessKey = {ACCESS_KEY}
+grails.plugin.awssdk.secretKey = {SECRET_KEY}
+```
+
+If you do not provide credentials in grails-app/conf/Config.groovy, a credentials provider chain will be used that searches for credentials in this order:
+
+- Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_KEY
+- Java System Properties - aws.accessKeyId and aws.secretKey
+- Instance profile credentials delivered through the Amazon EC2 metadata service (IAM role)
+
+
 Usage / Documentation
 ---------------------
 
@@ -11,13 +28,12 @@ To instantiate an S3 provider simply do:
 
 ```groovy
 import com.bertramlabs.plugins.karman.*
-def provider = new S3StorageProvider(accessKey: 'key', secret: 'secret')
+def provider = new S3StorageProvider()
 
 //example getting file contents
-def file = provider['mybucket']['exmaple.txt'] 
+def file = provider['mybucket']['example.txt']
 return file.text
 ```
-
 
 
 Check the Karman API Documentation for details on how to interace with cloud files:

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Wed Feb 19 20:46:56 EST 2014
-app.grails.version=2.2.4
+#Sun Feb 23 16:05:21 CET 2014
+app.grails.version=2.3.6
 app.name=karman-aws

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -12,7 +12,6 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        compile 'net.java.dev.jets3t:jets3t:0.9.0'
         build 'org.apache.httpcomponents:httpcore:4.2'
         build 'org.apache.httpcomponents:httpclient:4.2'
         runtime 'org.apache.httpcomponents:httpcore:4.2'
@@ -20,14 +19,13 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        runtime ':karman:0.1.1'
         build ':tomcat:7.0.50.1'
-        runtime ':hibernate:3.6.10.8'
-
         build(':release:3.0.1') {
-
             export = false
         }
+
+        runtime ':aws-sdk:1.7.1'
+        runtime ':karman:0.1.1'
     }
 }
 //grails.plugin.location."karman" = "../karman"

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,8 +1,9 @@
 grails.project.work.dir = 'target'
 
+grails.project.dependency.resolver = 'maven'
 grails.project.dependency.resolution = {
     inherits 'global'
-    log "warn"
+    log 'warn'
     legacyResolve false
     repositories {
         grailsCentral()
@@ -19,12 +20,14 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        // runtime ":karman:0.1.1"
-        build(":tomcat:$grailsVersion",
-              ":release:2.2.1") {
+        runtime ':karman:0.1.1'
+        build ':tomcat:7.0.50.1'
+        runtime ':hibernate:3.6.10.8'
+
+        build(':release:3.0.1') {
+
             export = false
         }
     }
 }
-
-grails.plugin.location."karman" = "../karman"
+//grails.plugin.location."karman" = "../karman"

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -8,27 +8,3 @@ log4j = {
         'org.hibernate',
         'net.sf.ehcache.hibernate'
 }
-
-// Uncomment and edit the following lines to start using Grails encoding & escaping improvements
-
-/* remove this line 
-// GSP settings
-grails {
-    views {
-        gsp {
-            encoding = 'UTF-8'
-            htmlcodec = 'xml' // use xml escaping instead of HTML4 escaping
-            codecs {
-                expression = 'html' // escapes values inside null
-                scriptlet = 'none' // escapes output from scriptlets in GSPs
-                taglib = 'none' // escapes output from taglibs
-                staticparts = 'none' // escapes output from static template parts
-            }
-        }
-        // escapes all not-encoded output at final stage of outputting
-        filteringCodecForContentType {
-            //'text/html' = 'html'
-        }
-    }
-}
-remove this line */

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -8,3 +8,27 @@ log4j = {
         'org.hibernate',
         'net.sf.ehcache.hibernate'
 }
+
+// Uncomment and edit the following lines to start using Grails encoding & escaping improvements
+
+/* remove this line 
+// GSP settings
+grails {
+    views {
+        gsp {
+            encoding = 'UTF-8'
+            htmlcodec = 'xml' // use xml escaping instead of HTML4 escaping
+            codecs {
+                expression = 'html' // escapes values inside null
+                scriptlet = 'none' // escapes output from scriptlets in GSPs
+                taglib = 'none' // escapes output from taglibs
+                staticparts = 'none' // escapes output from static template parts
+            }
+        }
+        // escapes all not-encoded output at final stage of outputting
+        filteringCodecForContentType {
+            //'text/html' = 'html'
+        }
+    }
+}
+remove this line */

--- a/test/unit/karman/aws/S3CloudFileSpec.groovy
+++ b/test/unit/karman/aws/S3CloudFileSpec.groovy
@@ -1,0 +1,154 @@
+package karman.aws
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.S3Object
+import com.amazonaws.services.s3.model.S3ObjectInputStream
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.bertramlabs.plugins.karman.S3CloudFile
+import com.bertramlabs.plugins.karman.S3Directory
+import com.bertramlabs.plugins.karman.S3StorageProvider
+import grails.plugin.awssdk.AmazonWebService
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import spock.lang.Specification
+
+@TestMixin(GrailsUnitTestMixin)
+class S3CloudFileSpec extends Specification {
+
+    static DIRECTORY_NAME = 'bucket-1'
+    static FILE_NAME = 'file-1'
+
+    S3StorageProvider provider
+    S3Directory directory
+    S3CloudFile file
+
+    def setup() {
+        provider = new S3StorageProvider()
+        provider.amazonWebService = Mock(AmazonWebService)
+        directory = new S3Directory(name: DIRECTORY_NAME, provider: provider)
+        file = new S3CloudFile(name: FILE_NAME,parent: directory)
+    }
+
+    void "Testing if file exists"() {
+        when:
+        def valid = file.exists()
+
+        then:
+        valid
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.listObjects(DIRECTORY_NAME, FILE_NAME) >> {
+                [objectSummaries: [new S3ObjectSummary(key: FILE_NAME, bucketName: DIRECTORY_NAME)]] as ObjectListing
+            }
+            client
+        }
+    }
+
+    void "Getting file text"() {
+        when:
+        def text = file.text
+
+        then:
+        text == 'Some text'
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.getObject(DIRECTORY_NAME, FILE_NAME) >> {
+                new S3Object(
+                        bucketName: directory.name,
+                        key: file.name,
+                        objectContent: new S3ObjectInputStream(new ByteArrayInputStream('Some text'.bytes), null)
+                )
+            }
+            client
+        }
+    }
+
+    void "Getting file UTF-8 text"() {
+        when:
+        def text = file.getText('UTF-8')
+
+        then:
+        text == 'Texte en français'
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.getObject(DIRECTORY_NAME, FILE_NAME) >> {
+                new S3Object(
+                        bucketName: directory.name,
+                        key: file.name,
+                        objectContent: new S3ObjectInputStream(new ByteArrayInputStream('Texte en français'.bytes), null)
+                )
+            }
+            client
+        }
+    }
+
+    void "Getting file bytes"() {
+        when:
+        def bytes = file.bytes
+
+        then:
+        bytes == 'Some text'.bytes
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.getObject(DIRECTORY_NAME, FILE_NAME) >> {
+                new S3Object(
+                        bucketName: directory.name,
+                        key: file.name,
+                        objectContent: new S3ObjectInputStream(new ByteArrayInputStream('Some text'.bytes), null)
+                )
+            }
+            client
+        }
+    }
+
+    void "Getting file input stream"() {
+        when:
+        def inputStream = file.inputStream
+
+        then:
+        inputStream
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.getObject(DIRECTORY_NAME, FILE_NAME) >> {
+                new S3Object(
+                        bucketName: directory.name,
+                        key: file.name,
+                        objectContent: new S3ObjectInputStream(new ByteArrayInputStream('Some text'.bytes), null)
+                )
+            }
+            client
+        }
+    }
+
+    void "Saving file"() {
+        given:
+        file.text = "Setting some value to this file"
+
+        when:
+        file.save()
+
+        then:
+        !file.summary
+        !file.object
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.putObject(DIRECTORY_NAME, FILE_NAME, _, _)
+            client
+        }
+    }
+
+    void "Deleting file"() {
+        when:
+        file.delete()
+
+        then:
+        file.existsFlag == false
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.deleteObject(DIRECTORY_NAME, FILE_NAME)
+            client
+        }
+    }
+
+}

--- a/test/unit/karman/aws/S3DirectorySpec.groovy
+++ b/test/unit/karman/aws/S3DirectorySpec.groovy
@@ -1,0 +1,132 @@
+package karman.aws
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.Bucket
+import com.amazonaws.services.s3.model.ObjectListing
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.bertramlabs.plugins.karman.S3Directory
+import com.bertramlabs.plugins.karman.S3StorageProvider
+import grails.plugin.awssdk.AmazonWebService
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import spock.lang.Specification
+
+@TestMixin(GrailsUnitTestMixin)
+class S3DirectorySpec extends Specification {
+
+    static DIRECTORY_NAME = 'bucket-1'
+
+    S3StorageProvider provider
+    S3Directory directory
+
+    def setup() {
+        provider = new S3StorageProvider()
+        provider.amazonWebService = Mock(AmazonWebService)
+        directory = new S3Directory(name: DIRECTORY_NAME, provider: provider)
+    }
+
+    void "Testing if directory exists"() {
+        when:
+        def valid = directory.exists()
+
+        then:
+        valid
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.doesBucketExist(DIRECTORY_NAME) >> {
+                true
+            }
+            client
+        }
+
+        when:
+        valid = directory.exists()
+
+        then:
+        !valid
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.doesBucketExist(DIRECTORY_NAME) >> {
+                false
+            }
+            client
+        }
+    }
+
+    void "Listing directory files"() {
+        when:
+        def files = directory.listFiles()
+
+        then:
+        files
+        files.size() == 2
+        files.first().name == 'key-1'
+        files.first().provider == provider
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.listObjects(_) >> {
+               [objectSummaries: [
+                       new S3ObjectSummary(key: 'key-1', bucketName: DIRECTORY_NAME),
+                       new S3ObjectSummary(key: 'key-2', bucketName: DIRECTORY_NAME)
+               ]] as ObjectListing
+            }
+            client
+        }
+    }
+
+    void "Getting file"() {
+        when:
+        def file = directory.getFile('file-1')
+
+        then:
+        file.name == 'file-1'
+        file.provider == provider
+        0 * provider.amazonWebService.getS3(_)
+
+        when:
+        file = directory['file-1']
+
+        then:
+        file.name == 'file-1'
+        file.provider == provider
+        0 * provider.amazonWebService.getS3(_)
+    }
+
+    void "Saving directory"() {
+        given:
+        String bucketName = 'new-bucket'
+        def newBucket = new S3Directory(name: bucketName, provider: provider)
+
+        when:
+        newBucket.save()
+
+        then:
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.createBucket(bucketName) >> {
+                new Bucket(bucketName)
+            }
+            client
+        }
+    }
+
+    void "Saving directory in a given region"() {
+        given:
+        String bucketName = 'new-bucket'
+        String regionName = 'eu-west-1'
+        def newBucket = new S3Directory(name: bucketName, provider: provider, region: regionName)
+
+        when:
+        newBucket.save()
+
+        then:
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.createBucket(bucketName, regionName) >> {
+                new Bucket(bucketName)
+            }
+            client
+        }
+    }
+
+}

--- a/test/unit/karman/aws/S3StorageProviderSpec.groovy
+++ b/test/unit/karman/aws/S3StorageProviderSpec.groovy
@@ -1,0 +1,57 @@
+package karman.aws
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.Bucket
+import com.bertramlabs.plugins.karman.S3StorageProvider
+import grails.plugin.awssdk.AmazonWebService
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import spock.lang.Specification
+
+@TestMixin(GrailsUnitTestMixin)
+class S3StorageProviderSpec extends Specification {
+
+    S3StorageProvider provider
+
+    def setup() {
+        provider = new S3StorageProvider()
+        provider.amazonWebService = Mock(AmazonWebService)
+    }
+
+    void "Getting directories"() {
+        when:
+        def directories = provider.getDirectories()
+
+        then:
+        directories
+        directories.size() == 2
+        1 * provider.amazonWebService.getS3(_) >> {
+            def client = Mock(AmazonS3Client)
+            1 * client.listBuckets() >> {
+                [new Bucket('bucket-1'), new Bucket('bucket-2')]
+            }
+            client
+        }
+    }
+
+    void "Getting directory"() {
+        when:
+        def directory = provider.getDirectory('bucket-1')
+
+        then:
+        directory
+        directory.name == 'bucket-1'
+        directory.provider == provider
+        0 * provider.amazonWebService.getS3(_)
+
+        when:
+        directory = provider['bucket-1']
+
+        then:
+        directory
+        directory.name == 'bucket-1'
+        directory.provider == provider
+        0 * provider.amazonWebService.getS3(_)
+    }
+
+}

--- a/web-app/WEB-INF/applicationContext.xml
+++ b/web-app/WEB-INF/applicationContext.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="
-http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="grailsApplication" class="org.codehaus.groovy.grails.commons.GrailsApplicationFactoryBean">
 		<description>Grails application factory bean</description>
@@ -30,4 +29,6 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 			<value>utf-8</value>
 		</property>
 	</bean>
+
+	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean" />
 </beans>

--- a/web-app/WEB-INF/tld/spring.tld
+++ b/web-app/WEB-INF/tld/spring.tld
@@ -1,311 +1,457 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE taglib PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.2//EN" "http://java.sun.com/dtd/web-jsptaglibrary_1_2.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
+		version="2.0">
 
-<taglib>
-
-	<tlib-version>1.1.1</tlib-version>
-
-	<jsp-version>1.2</jsp-version>
-
-	<short-name>Spring</short-name>
-
+	<description>Spring Framework JSP Tag Library</description>
+	<tlib-version>3.0</tlib-version>
+	<short-name>spring</short-name>
 	<uri>http://www.springframework.org/tags</uri>
 
-	<description>Spring Framework JSP Tag Library. Authors: Rod Johnson, Juergen Hoeller</description>
-
-
 	<tag>
-
-		<name>htmlEscape</name>
-		<tag-class>org.springframework.web.servlet.tags.HtmlEscapeTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Sets default HTML escape value for the current page.
 			Overrides a "defaultHtmlEscape" context-param in web.xml, if any.
 		</description>
-
+		<name>htmlEscape</name>
+		<tag-class>org.springframework.web.servlet.tags.HtmlEscapeTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>Set the default value for HTML escaping, to be put
+				into the current PageContext.</description>
 			<name>defaultHtmlEscape</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>escapeBody</name>
-		<tag-class>org.springframework.web.servlet.tags.EscapeBodyTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Escapes its enclosed body content, applying HTML escaping and/or JavaScript escaping.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>escapeBody</name>
+		<tag-class>org.springframework.web.servlet.tags.EscapeBodyTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value.
+			Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>message</name>
-		<tag-class>org.springframework.web.servlet.tags.MessageTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Retrieves the message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>message</name>
+		<tag-class>org.springframework.web.servlet.tags.MessageTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>A MessageSourceResolvable argument (direct or through JSP EL).
+				Fits nicely when used in conjunction with Spring's own validation error
+				classes which all implement the MessageSourceResolvable interface. For
+				example, this allows you to iterate over all of the errors in a form,
+				passing each error (using a runtime expression) as the value of this
+				'message' attribute, thus effecting the easy display of such error
+				messages.</description>
+			<name>message</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The code (key) to use when looking up the message.
+			If code is not provided, the text attribute will be used.</description>
 			<name>code</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set optional message arguments for this tag, as a
+			(comma-)delimited String (each String argument can contain JSP EL),
+			an Object array (used as argument array), or a single Object (used
+			as single argument).</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The separator character to be used for splitting the
+			arguments string value; defaults to a 'comma' (',').</description>
+			<name>argumentSeparator</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Default text to output when a message for the given code
+			could not be found. If both text and code are not set, the tag will
+			output null.</description>
 			<name>text</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result
+			gets outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exporting the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value. Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>theme</name>
-		<tag-class>org.springframework.web.servlet.tags.ThemeTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Retrieves the theme message with the given code, or text if code isn't resolvable.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>theme</name>
+		<tag-class>org.springframework.web.servlet.tags.ThemeTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>A MessageSourceResolvable argument (direct or through JSP EL).</description>
+			<name>message</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The code (key) to use when looking up the message.
+			If code is not provided, the text attribute will be used.</description>
 			<name>code</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set optional message arguments for this tag, as a
+			(comma-)delimited String (each String argument can contain JSP EL),
+			an Object array (used as argument array), or a single Object (used
+			as single argument).</description>
 			<name>arguments</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The separator character to be used for splitting the
+			arguments string value; defaults to a 'comma' (',').</description>
+			<name>argumentSeparator</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Default text to output when a message for the given code
+			could not be found. If both text and code are not set, the tag will
+			output null.</description>
 			<name>text</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result
+			gets outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exporting the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set JavaScript escaping for this tag, as boolean value. Default is false.</description>
 			<name>javaScriptEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>hasBindErrors</name>
-		<tag-class>org.springframework.web.servlet.tags.BindErrorsTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides Errors instance in case of bind errors.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>hasBindErrors</name>
+		<tag-class>org.springframework.web.servlet.tags.BindErrorsTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>errors</name-given>
 			<variable-class>org.springframework.validation.Errors</variable-class>
 		</variable>
-
 		<attribute>
+			<description>The name of the bean in the request, that needs to be
+			inspected for errors. If errors are available for this bean, they
+			will be bound under the 'errors' key.</description>
 			<name>name</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value.
+			Overrides the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>nestedPath</name>
-		<tag-class>org.springframework.web.servlet.tags.NestedPathTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Sets a nested path to be used by the bind tag's path.
 		</description>
-
+		<name>nestedPath</name>
+		<tag-class>org.springframework.web.servlet.tags.NestedPathTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>nestedPath</name-given>
 			<variable-class>java.lang.String</variable-class>
 		</variable>
-
 		<attribute>
+			<description>Set the path that this tag should apply. E.g. 'customer'
+			to allow bind paths like 'address.street' rather than
+			'customer.address.street'.</description>
 			<name>path</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>bind</name>
-		<tag-class>org.springframework.web.servlet.tags.BindTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides BindStatus object for the given bind path.
 			The HTML escaping flag participates in a page-wide or application-wide setting
 			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
 		</description>
-
+		<name>bind</name>
+		<tag-class>org.springframework.web.servlet.tags.BindTag</tag-class>
+		<body-content>JSP</body-content>
 		<variable>
 			<name-given>status</name-given>
 			<variable-class>org.springframework.web.servlet.support.BindStatus</variable-class>
 		</variable>
-
 		<attribute>
+			<description>The path to the bean or bean property to bind status
+			information for. For instance account.name, company.address.zipCode
+			or just employee. The status object will exported to the page scope,
+			specifically for this bean or bean property</description>
 			<name>path</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set whether to ignore a nested path, if any. Default is to not ignore.</description>
 			<name>ignoreNestedPath</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides
+			the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 	</tag>
 
-
 	<tag>
-
-		<name>transform</name>
-		<tag-class>org.springframework.web.servlet.tags.TransformTag</tag-class>
-		<body-content>JSP</body-content>
-
 		<description>
 			Provides transformation of variables to Strings, using an appropriate
 			custom PropertyEditor from BindTag (can only be used inside BindTag).
 			The HTML escaping flag participates in a page-wide or application-wide setting
-			(i.e. by HtmlEscapeTag or a "defaultHtmlEscape" context-param in web.xml).
+			(i.e. by HtmlEscapeTag or a 'defaultHtmlEscape' context-param in web.xml).
 		</description>
-
+		<name>transform</name>
+		<tag-class>org.springframework.web.servlet.tags.TransformTag</tag-class>
+		<body-content>JSP</body-content>
 		<attribute>
+			<description>The value to transform. This is the actual object you want
+			to have transformed (for instance a Date). Using the PropertyEditor that
+			is currently in use by the 'spring:bind' tag.</description>
 			<name>value</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The string to use when binding the result to the page,
+			request, session or application scope. If not specified, the result gets
+			outputted to the writer (i.e. typically directly to the JSP).</description>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>The scope to use when exported the result to a variable.
+			This attribute is only used when var is also set. Possible values are
+			page, request, session and application.</description>
 			<name>scope</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
-
 		<attribute>
+			<description>Set HTML escaping for this tag, as boolean value. Overrides
+			the default HTML escaping setting for the current page.</description>
 			<name>htmlEscape</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+	</tag>
 
+	<tag>
+		<description>URL tag based on the JSTL c:url tag.  This variant is fully 
+		backwards compatible with the standard tag.  Enhancements include support 
+		for URL template parameters.</description>
+		<name>url</name>
+		<tag-class>org.springframework.web.servlet.tags.UrlTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The URL to build.  This value can include template place holders 
+			that are replaced with the URL encoded value of the named parameter.  Parameters 
+			must be defined using the param tag inside the body of this tag.</description>
+			<name>value</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Specifies a remote application context path.  The default is the 
+			current application context path.</description>
+			<name>context</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The name of the variable to export the URL value to.</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The scope for the var.  'application', 'session', 'request' and 
+			'page' scopes are supported.  Defaults to page scope.  This attribute has no 
+			effect unless the var attribute is also defined.</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set HTML escaping for this tag, as a boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
+			<name>htmlEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set JavaScript escaping for this tag, as a boolean value.
+			Default is false.</description>
+			<name>javaScriptEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<description>Parameter tag based on the JSTL c:param tag.  The sole purpose is to 
+		support params inside the spring:url tag.</description>
+		<name>param</name>
+		<tag-class>org.springframework.web.servlet.tags.ParamTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The name of the parameter.</description>
+			<name>name</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The value of the parameter.</description>
+			<name>value</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<description>Evaluates a Spring expression (SpEL) and either prints the result or assigns it to a variable.</description>
+		<name>eval</name>
+		<tag-class>org.springframework.web.servlet.tags.EvalTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The expression to evaluate.</description>
+			<name>expression</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The name of the variable to export the evaluation result to.</description>
+			<name>var</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The scope for the var.  'application', 'session', 'request' and 
+			'page' scopes are supported.  Defaults to page scope.  This attribute has no 
+			effect unless the var attribute is also defined.</description>
+			<name>scope</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set HTML escaping for this tag, as a boolean value. Overrides the
+			default HTML escaping setting for the current page.</description>
+			<name>htmlEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Set JavaScript escaping for this tag, as a boolean value.  Default is false.</description>
+			<name>javaScriptEscape</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 	</tag>
 
 </taglib>


### PR DESCRIPTION
Here is a first version based on AWS SDK!

I've added bucket creation capabilities with save() to S3Directory and getURL(expirationDate) to S3CloudFile to get pre-signed URL.

By default, ACL is set to private, but you can pass a cannedACL when saving a file.

``` groovy
s3[bucketName]['test.txt'].text("Setting the text value").save(CannedAccessControlList.PublicRead)
```
